### PR TITLE
Use intercal for transpose symbol

### DIFF
--- a/docs/dynamics.md
+++ b/docs/dynamics.md
@@ -25,7 +25,7 @@ $$A_{ij}'(t) = T_{ij}(t) \sin(\Theta_{ij}(t))$$
 $$\theta_i'(t) = \beta \sum_j T_{ij}(t) A_{ij}^\alpha(t) \sin(\Theta_{ij}(t))$$
 where $\alpha$ and $\beta$ are scaling parameters and $\mathbf{T}(t)$ is an interaction matrix constructing by generating a random matrix, $\mathbf{M}(t)$, with elements in $[0, 1)$ and comparing it to the network's adjacency matrix, $\mathbf{A}(t)$. Where $M_{ij}(t) < A_{ij}(t)$, $T_{ij}(t) = 1$ and nodes $i$ and $j$ interact. Otherwise $T_{ij} = 0$ and nodes $i$ and $j$ don't interact at that time.
 where $\Theta_{ij}(t)$ are the elements of the matrix of differences in node attitudes:
-$$\mathbf{\Theta}_{ij}(t) = \mathbf{\theta}(t) - \mathbf{\theta}^{\top}(t)$$
+$$\mathbf{\Theta}_{ij}(t) = \mathbf{\theta}(t) - \mathbf{\theta}^{\intercal}(t)$$
 
 This produces an adaptive complex network where edge strengths and node attitudes are reinforced according to each other over time. Note that this is a modified Kuramoto model ([Kuramoto, 1975](https://doi.org/10.1007/BFb0013365)), with the modifications:
 1. The mean over all phases is replaced by the simple sum.


### PR DESCRIPTION
Apparently `\top` doesn't render well on screen. `\intercal` renders better.