### PR TITLE
Add laplace, von Mises, and uniform attitude distributions

### DIFF
--- a/nim/core.py
+++ b/nim/core.py
@@ -193,7 +193,7 @@ class NetworkModel:
         self : Self@NetworkModel
             An instance of the NetworkModel object.
 
-        """
+        """  # noqa: E501
         rng = np.random.default_rng()
         if distribution == "normal":
             attitudes = rng.normal(


### PR DESCRIPTION
Addresses issue #45 

## Proposed changes

Add support for invoking the following distributions when initializing attitudes:
- [Uniform](a)
- [Laplace](https://numpy.org/doc/stable/reference/random/generated/numpy.random.Generator.laplace.html#numpy.random.Generator.laplace)
- [von Mises](https://numpy.org/doc/stable/reference/random/generated/numpy.random.Generator.vonmises.html#numpy.random.Generator.vonmises)

To accommodate these, the parameters of the `core.NetworkModel.initialize_attitudes()` method have been reworked to support arbitrary two-parameter distributions.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
