### PR TITLE
📝DOC: Adjust display options

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1,3 +1,3 @@
 # netechos.core
 
-::: netechos.core.NetworkModel
+::: netechos.core

--- a/docs/api-reference/plot.md
+++ b/docs/api-reference/plot.md
@@ -1,3 +1,3 @@
 # netechos.plot
 
-::: netechos.plot.NetworkPlot
+::: netechos.plot

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,10 @@ plugins:
             show_symbol_type_heading: true
             show_symbol_type_toc: true
             parameter_headings: true
+            docstring_options:
+              ignore_init_summary: true
+            merge_init_into_class: true
+            show_root_toc_entry: false
 
 theme:
   name: material


### PR DESCRIPTION
Make the mkdocstrings formatter show the module name as the top-level heading and structure the subheadings properly