### PR TITLE
CI: Use Astral's official uv action

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,5 @@
 name: Pytest
-on: [push]
+on: push
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -10,9 +10,9 @@ jobs:
         - "3.12"
         - "3.13"
     steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
     - uses: actions/checkout@v4
-    - name: Set up uv
-      run: curl -LsSf https://astral.sh/uv/install.sh | sh
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
## Proposed changes
Switch `pytest` workflow over to the new official action for installing uv.
